### PR TITLE
How to use Markdown inline code containing backticks on VSCode Marketplace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ document format.
     * inline  `\(...\)`
     * display `\[...\]`
   * `gitlab`
-    * inline ``$`...`$``</code>
+    * inline ``$`...`$``
     * display ` ```math ... ``` `
 
 ![mdmath editing](./img/mdmath.gif)


### PR DESCRIPTION
This extra close tag breaks display on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=goessner.mdmath).

In addition, the ``display ```` ```math ... ``` ```` `` can be shortened as ``display ` ```math ... ``` ` `` with same effect. (I love this feature of CommonMark.) I can change it in this pull request if you like.