### PR TITLE
New Feature: Save HTML to file without copy & paste

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### [2.3.4]() (Awaiting Review)  on October 25, 2018
+* Command to save HTML to file
+* Autosave option for saving HTML when Markdown file is changed
+* Ability to configure where HTML files are saved
+
 ###  [2.3.3]() on September 07, 2018
 * Add support for [Kramdown](https://kramdown.gettalong.org/) . Simply write `"mdmath.delimiters": "kramdown"` into your user settings for activating it. Please note, that syntax highlighting is only properly supported with `dollars`.
 

--- a/extension.js
+++ b/extension.js
@@ -20,23 +20,84 @@ ${html}
 exports.activate = function activate(context) {
     const kt = require('katex'),
           tm = require('markdown-it-texmath').use(kt),
+          path = require('path'),
+          fs = require('fs'),
+          mkdirp = require('mkdirp').sync,
           cfg = (key) => vscode.workspace.getConfiguration('mdmath')[key],
           delimiters = cfg('delimiters') || 'dollars',
+          runIf = (cond, f) => {
+                return () => {
+                    cond() && f() 
+                }
+          },
+          infoMsg = (msg) => {
+                  vscode.window.showInformationMessage(`Markdown + Math: ${msg}`);
+          },
+          errMsg = (msg) => {
+                 vscode.window.showErrorMessage(`Markdown + Math: ${msg}`);
+          },
+          makeHTML = () => {
+                   const doc = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document;
+                   if (!doc || doc.languageId !== 'markdown')
+                       return infoMsg('Active document is no markdown source document!');
+                   if (!mdit)
+                       return infoMsg('Corresponding markdown preview document needs to be opened at least once!');
+                    
+                   return clipTmpl(mdit.render(doc.getText()))
+               
+          },
+          outputLocationOf = (fsPath) => {
+                           const root = vscode.workspace.getWorkspaceFolder(fsPath) || vscode.workspace.rootPath,
+                                 parsed = path.parse(fsPath),
+                                 savePath = cfg('savePath')
+                                                .replace('${file.name}', parsed.name)
+                                                .replace('${file.ext}', parsed.ext),
+                                 out = savePath.startsWith('/') ? path.resolve(root, `.${savePath}`) : path.resolve(parsed.dir, savePath);
+
+                           return path.isAbsolute(out) ? out : path.resolve(parsed.dir, `./${parsed.name}.html`);
+          },
           clip = () => {
-               const doc = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document;
-               if (!doc || doc.languageId !== 'markdown')
-                   return vscode.window.showInformationMessage('Active document is no markdown source document!');
-               if (!mdit)
-                   return vscode.window.showInformationMessage('Corresponding markdown preview document needs to be opened at least once!');
                if (!cb) cb = require('clipboardy');
-               cb.write(clipTmpl(mdit.render(doc.getText())))
-                 .then(()=>vscode.window.showInformationMessage('Html copied to clipboard!'),
-                       (err)=>vscode.window.showInformationMessage('Html copying to clipboard failed: '+err.message));
+               cb.write(makeHTML())
+                 .then(()=>infoMsg('Html copied to clipboard!'),
+                      (err)=>errMsg('Html copying to clipboard failed: ' + err.message));
+          },
+          save = (uri) => {
+               try {
+                    uri = uri || vscode.window.activeTextEditor._documentData._uri;
+                    const dest = outputLocationOf(uri.fsPath);
+                    
+
+                    mkdirp(path.parse(dest).dir);
+
+                    fs.writeFileSync(dest, makeHTML(), 'UTF-8');
+                    infoMsg(`Html saved to ${dest}!`);
+               } catch (err) {
+                    errMsg('Saving html failed: ' + err.message);
+               }
+                      
           };
     let   mdit = null,
           cb = null;
 
+    
+    ((watcher) => {
+        const autosave = runIf(() => { return cfg('autosave') }, save);
+        watcher.onDidChange(autosave); watcher.onDidCreate(autosave);
+        watcher.onDidDelete((uri) => {
+            try {
+                const dest = outputLocationOf(uri.fsPath);
+                fs.unlinkSync(dest);
+                infoMsg(`Removed ${dest}.`);
+            } catch (err) {
+                errMsg('Removing file failed: ' + err.message);
+            }
+        });
+
+    })(vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(vscode.workspace.rootPath, '**/*.md')));
+    
     context.subscriptions.push(vscode.commands.registerCommand('extension.clipToHtml', clip));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.renderToHtml', save));
     return {
         extendMarkdownIt: function(md) {
             return (mdit = md).use(tm, {delimiters:delimiters});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,16 @@
           "type": "string",
           "default": "dollars",
           "description": "Math formula delimiters."
+        },
+        "mdmath.savePath": {
+          "type": "string",
+          "default": "./${file.name}.html",
+          "description": "Relative path to save generated HTML files. \nPaths are interpreted relative to the source file with the workspace folder as the root directory. \nYou can use the variables ${file.name} and ${file.ext}."
+        },
+        "mdmath.autosave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run the 'Save Markdown+Math to HTML' command when a markdown file is changed."
         }
       }
     },
@@ -58,12 +68,22 @@
         "command": "extension.clipToHtml",
         "title": "Clip Markdown+Math to HTML",
         "category": "Markdown"
+      },
+      {
+        "command": "extension.renderToHtml",
+        "title": "Save Markdown+Math to HTML",
+        "category": "Markdown"
       }
     ],
     "keybindings": [
       {
         "command": "extension.clipToHtml",
         "key": "ctrl+K .",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "extension.renderToHtml",
+        "key": "ctrl+K ,",
         "when": "editorTextFocus"
       }
     ],
@@ -109,6 +129,7 @@
     "markdown-it-texmath": "^0.5.2",
     "match-at": "^0.1.0",
     "mdurl": "^1.0.1",
+    "mkdirp": "^0.5.1",
     "npm-run-path": "^2.0.0",
     "p-finally": "^1.0.0",
     "path-key": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,9 @@ npm install
 ## Default User Settings
 ```json
   // Path to custom stylesheet file (css).
-  "mdmath.delimiters": "dollars"
+  "mdmath.delimiters": "dollars",
+  "mdmath.savePath": "./${file.name}.html",
+  "mdmath.autosave": false
 ```
 
 ## Dependencies


### PR DESCRIPTION
When dealing with files with a lot of Latex copying the content and then pasting it into a new HTML file is can cause slow down while VS Code deals with the large file at first. 
It also isn't an optimal workflow for dealing with multiple files or repeated editing because it requires a manual step each time you want to update it.

To address this I've added a new command that allows you to save the HTML directly to a file. 
By default it saves in the same directory as `.html` instead of `.md`, but this is fully configurable.
There's also an option to enable auto save so that whenever you save changes to a markdown file the HTML file is created/updated.

A nice example of how this could be useful is setting the save path to `/docs/${file.name}.html` and enabling autosave.
For someone hosting their Markdown + Math documents in a GitHub repository enabling Pages would allow the automatic creation of files that can be viewed by anyone, anywhere with these settings.

I haven't updated the README beyond the new default values or updated the version so a maintainer can do it properly.