### PR TITLE
add support for markdown.styles setting

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,7 +8,7 @@ const vscode = require('vscode'),
       htmlTmpl = (html,usrcss) => `<!doctype html><html><head><meta charset="utf-8">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js">
-<link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">
 <link rel="stylesheet" href="https://gitcdn.xyz/repo/goessner/mdmath/master/css/texmath.css">
 <link rel="stylesheet" href="https://gitcdn.xyz/repo/goessner/mdmath/master/css/vscode-texmath.css">
 ${usrcss ? `<link rel="stylesheet" href="${usrcss}">` : ''}


### PR DESCRIPTION
There was support for custom stylesheets (in preview and saved HTML files) in the `htmlTmpl` function, but this feature was unused. In particular, `htmlTmpl` accepts a second argument in the form of a URL to a custom stylesheet. This pull request enables support for custom stylesheets by passing the URL in `markdown.styles: []` as the second argument to `htmlTmpl`.