### PR TITLE
Add "math" to "contentName"

### DIFF
--- a/syntaxes/dollars_display.json
+++ b/syntaxes/dollars_display.json
@@ -6,7 +6,7 @@
 			"name":"display-dollars",
 			"begin": "(^|\\G)\\${1,2}",
 			"end": "\\${1,2}",
-            "contentName": "markup.inline.raw"
+            "contentName": "markup.math.inline.raw"
 		}
 	],
 	"scopeName": "markdown.math.display"

--- a/syntaxes/dollars_inline.json
+++ b/syntaxes/dollars_inline.json
@@ -6,7 +6,7 @@
 			"name":"inline-dollars",
 			"begin": "(^|\\s*)\\${1,2}",
 			"end": "\\${1,2}",
-            "contentName": "markup.inline.raw"
+            "contentName": "markup.math.inline.raw"
 		}
 	],
 	"scopeName": "markdown.math.inline"


### PR DESCRIPTION
The textmate scopes are "markup.inline.raw" and "inline-dollars". At the same time, I used HyperSnips extension to insert snippets according to the "math" environment. Therefore, I add "math" to  the "contentName" so that the HyperSnips can work smoothly.